### PR TITLE
Message body is returned in raw format and requires base64 decode.

### DIFF
--- a/outlook.py
+++ b/outlook.py
@@ -4,6 +4,7 @@ import smtplib
 import datetime
 import email.mime.multipart
 import config
+import base64
 
 
 class Outlook():
@@ -199,3 +200,6 @@ class Outlook():
 
     def mailall(self):
         return self.email_message
+
+    def mailbodydecoded(self):
+        return base64.b64decode(self.mailbody())

--- a/outlook.py
+++ b/outlook.py
@@ -202,4 +202,4 @@ class Outlook():
         return self.email_message
 
     def mailbodydecoded(self):
-        return base64.b64decode(self.mailbody())
+        return base64.urlsafe_b64decode(self.mailbody())


### PR DESCRIPTION
When returning and printing the message body it is returned in base64 encoded format. 

I'm not sure if it was your intention, but I thought I'd add a function that optionally allows you to return the mail body in a decoded format

```
mail = outlook.Outlook()
mail.login(FROM_EMAIL, FROM_PWD)
mail.inbox()
mail.unread()
print(mail.mailbodydecoded())
```

Based on information here: [https://stackoverflow.com/questions/24597906/email-body-is-returned-as-encrypted-text-how-do-i-read-the-actual-message](https://stackoverflow.com/questions/24597906/email-body-is-returned-as-encrypted-text-how-do-i-read-the-actual-message)